### PR TITLE
Fix InstallDate parsing in CleanupAssistant

### DIFF
--- a/CleanupAssistant.ps1
+++ b/CleanupAssistant.ps1
@@ -146,7 +146,8 @@ function Get-InstalledPrograms {
             ForEach-Object {
                 $instDate = $null
                 if ($_.InstallDate -and $_.InstallDate -match '^\d{8}$') {
-                    [void][datetime]::TryParseExact($_.InstallDate,'yyyyMMdd',$null,[System.Globalization.DateTimeStyles]::None,[ref]$instDate)
+                    $rawDate = [string]$_.InstallDate
+                    [void][datetime]::TryParseExact($rawDate,'yyyyMMdd',$null,[System.Globalization.DateTimeStyles]::None,[ref]$instDate)
                 }
                 [pscustomobject]@{
                     DisplayName     = $_.DisplayName


### PR DESCRIPTION
## Summary
- fix InstallDate parsing when registry value is numeric

## Testing
- `pwsh -v`
- `pwsh parse_test.ps1`

------
https://chatgpt.com/codex/tasks/task_e_688c6b0b26e88332a5c61e4a1d6bbfac