### PR TITLE
Fix InstallDate parsing

### DIFF
--- a/CleanupAssistant.ps1
+++ b/CleanupAssistant.ps1
@@ -147,7 +147,16 @@ function Get-InstalledPrograms {
                 $instDate = $null
                 if ($_.InstallDate -and $_.InstallDate -match '^\d{8}$') {
                     $rawDate = [string]$_.InstallDate
-                    [void][datetime]::TryParseExact($rawDate,'yyyyMMdd',$null,[System.Globalization.DateTimeStyles]::None,[ref]$instDate)
+                    try {
+                        $instDate = [datetime]::ParseExact(
+                            $rawDate,
+                            'yyyyMMdd',
+                            [System.Globalization.CultureInfo]::InvariantCulture,
+                            [System.Globalization.DateTimeStyles]::None
+                        )
+                    } catch {
+                        $instDate = $null
+                    }
                 }
                 [pscustomobject]@{
                     DisplayName     = $_.DisplayName


### PR DESCRIPTION
## Summary
- parse registry InstallDate with ParseExact instead of TryParseExact

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c62aa66f08332afab9e5c8ede7295