### PR TITLE
Trim user input

### DIFF
--- a/CleanupAssistant.ps1
+++ b/CleanupAssistant.ps1
@@ -20,7 +20,7 @@ function Prompt-Input {
         [string]$Prompt
     )
     Write-Host $Prompt -ForegroundColor Cyan
-    Read-Host
+    return (Read-Host).Trim()
 }
 
 function Confirm-Choice {


### PR DESCRIPTION
## Summary
- sanitize input by trimming Read-Host output

## Testing
- `pwsh --version`
- `pwsh -NoLogo -Command 'function Prompt-Input { param([string]$Prompt); Write-Host $Prompt -ForegroundColor Cyan; return (Read-Host).Trim(); }; $res = Prompt-Input "Enter key"; Write-Output ("Key=" + $res)' <<'EOF'
abc123   
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688c8d1467248332b626c89e7be337d0